### PR TITLE
Fixing and cleaning up the About page

### DIFF
--- a/about/impl/src/commonMain/kotlin/activity/dashboard/AboutPresenterImpl.kt
+++ b/about/impl/src/commonMain/kotlin/activity/dashboard/AboutPresenterImpl.kt
@@ -1,10 +1,8 @@
 package activity.dashboard
 
 import activity.dashboard.AboutPresenter.Model
-import activity.dashboard.common.logging.Logger
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import me.tatarka.inject.annotations.Inject
 import software.amazon.lastmile.kotlin.inject.anvil.AppScope
@@ -13,13 +11,14 @@ import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
 @Inject
 @ContributesBinding(AppScope::class)
 class AboutPresenterImpl(
-    private val aboutRepository: AboutRepository,
+    private val externalEventHandler: ExternalEventHandler,
 ) : AboutPresenter {
     @Composable
     override fun present(input: Unit): Model {
-        val showAbout = remember { aboutRepository.showAbout.value }
-        Logger.log("kellardw showAbout: $showAbout")
-
-        return Model(url = "")
+        return Model {
+            when (it) {
+                AboutPresenter.Event.Coffee -> externalEventHandler.onBuyMeACoffeeClick()
+            }
+        }
     }
 }

--- a/about/impl/src/commonMain/kotlin/activity/dashboard/AboutRenderer.kt
+++ b/about/impl/src/commonMain/kotlin/activity/dashboard/AboutRenderer.kt
@@ -3,6 +3,7 @@ package activity.dashboard
 import activity.dashboard.AboutPresenter.Model
 import activity.dashboard.common.theme.ActivityDashboardTheme
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -16,7 +17,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.unit.dp
 import software.amazon.app.platform.inject.ContributesRenderer
 import software.amazon.app.platform.renderer.ComposeRenderer
@@ -64,7 +64,11 @@ class AboutRenderer : ComposeRenderer<Model>() {
                     body = AboutText.contact,
                 )
 
-                Spacer(modifier = Modifier.height(48.dp)) // Padding for bottom safe area
+                SectionDivider()
+
+                BuyMeACoffeeSection(model)
+
+                Spacer(modifier = Modifier.height(48.dp))
             }
         }
     }
@@ -105,6 +109,23 @@ class AboutRenderer : ComposeRenderer<Model>() {
             modifier = Modifier.padding(vertical = 8.dp),
             thickness = 1.dp,
             color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.1f),
+        )
+    }
+
+    @Composable
+    fun BuyMeACoffeeSection(model: Model) {
+        Section(
+            title = "Support the Project",
+            body = AboutText.supportProject,
+        )
+        Text(
+            text = "Buy me a coffee",
+            modifier =
+                Modifier
+                    .padding(top = 4.dp)
+                    .clickable { model.onEvent(AboutPresenter.Event.Coffee) },
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.primary,
         )
     }
 }

--- a/about/impl/src/commonMain/kotlin/activity/dashboard/AboutRepositoryImpl.kt
+++ b/about/impl/src/commonMain/kotlin/activity/dashboard/AboutRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package activity.dashboard
 
-import activity.dashboard.common.logging.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -17,7 +16,6 @@ class AboutRepositoryImpl : AboutRepository {
     override val showAbout: StateFlow<Boolean> = _showAbout.asStateFlow()
 
     override fun toggleAbout(override: Boolean?) {
-        Logger.log("kellardw")
         _showAbout.value = override ?: !_showAbout.value
     }
 }

--- a/about/impl/src/commonMain/kotlin/activity/dashboard/AboutText.kt
+++ b/about/impl/src/commonMain/kotlin/activity/dashboard/AboutText.kt
@@ -22,4 +22,9 @@ object AboutText {
         """
         If you have any questions, feedback, or need support, please don’t hesitate to contact us at patchroot.dev@gmail.com. We’re committed to continuously improving the application and greatly appreciate your input.
         """.trimIndent()
+
+    val supportProject =
+        """
+        Enjoying the app? If you find it helpful and would like to support continued development, consider buying us a coffee. Your support keeps this project alive and thriving!
+        """.trimIndent()
 }

--- a/about/impl/src/wasmJsMain/kotlin/activity/dashboard/WasmExternalEventHandler.kt
+++ b/about/impl/src/wasmJsMain/kotlin/activity/dashboard/WasmExternalEventHandler.kt
@@ -1,0 +1,16 @@
+package activity.dashboard
+
+import kotlinx.browser.window
+import me.tatarka.inject.annotations.Inject
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class WasmExternalEventHandler : ExternalEventHandler {
+    override fun onBuyMeACoffeeClick() {
+        window.open("https://buymeacoffee.com/patchroot", "_blank")
+    }
+}

--- a/about/public/src/commonMain/kotlin/activity/dashboard/AboutPresenter.kt
+++ b/about/public/src/commonMain/kotlin/activity/dashboard/AboutPresenter.kt
@@ -5,6 +5,10 @@ import software.amazon.app.platform.presenter.molecule.MoleculePresenter
 
 interface AboutPresenter : MoleculePresenter<Unit, AboutPresenter.Model> {
     data class Model(
-        val url: String,
+        val onEvent: (Event) -> Unit,
     ) : BaseModel
+
+    sealed interface Event {
+        data object Coffee : Event
+    }
 }

--- a/about/public/src/commonMain/kotlin/activity/dashboard/ExternalEventHandler.kt
+++ b/about/public/src/commonMain/kotlin/activity/dashboard/ExternalEventHandler.kt
@@ -1,0 +1,5 @@
+package activity.dashboard
+
+interface ExternalEventHandler {
+    fun onBuyMeACoffeeClick()
+}

--- a/composeApp/src/wasmJsMain/kotlin/activity/dashboard/HashRouting.kt
+++ b/composeApp/src/wasmJsMain/kotlin/activity/dashboard/HashRouting.kt
@@ -1,0 +1,37 @@
+package activity.dashboard
+
+import kotlinx.browser.window
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Observes the browser's URL hash and updates the application state accordingly.
+ *
+ * This is an experimental approach to handling routing in a Compose for Web (WASM) application
+ * using URL anchors (e.g. `#privacy`). It reads the current hash on startup and sets up a listener
+ * for future hash changes using the browser's native `onhashchange` event.
+ *
+ * If the hash is `#privacy`, it updates the [AboutRepository] to show the About view. Otherwise,
+ * it clears that state.
+ *
+ * This approach allows basic view-based routing without a full navigation framework. It should be
+ * considered a temporary or lightweight solution until a more robust solution is implemented.
+ *
+ */
+fun handleHashRouting(
+    aboutRepository: AboutRepository,
+    scope: CoroutineScope,
+) {
+    if (window.location.hash.removePrefix("#") == "privacy") {
+        scope.launch {
+            aboutRepository.toggleAbout(override = true)
+        }
+    }
+
+    window.onhashchange = {
+        val hash = window.location.hash.removePrefix("#")
+        scope.launch {
+            aboutRepository.toggleAbout(override = hash == "privacy")
+        }
+    }
+}

--- a/composeApp/src/wasmJsMain/kotlin/activity/dashboard/Main.kt
+++ b/composeApp/src/wasmJsMain/kotlin/activity/dashboard/Main.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
 import kotlinx.browser.document
@@ -22,6 +23,20 @@ private fun AppPlatform() {
         remember {
             Application().apply { create(WasmJsAppComponent::class.create(this)) }
         }
+
+    val coroutineScope = rememberCoroutineScope()
+    // Set up experimental hash-based routing to toggle the About view based on the URL anchor (e.g. #privacy)
+    // This allows directly linking to the about page to display the privacy information.
+    DisposableEffect(Unit) {
+        handleHashRouting(
+            aboutRepository =
+                application.rootScope
+                    .diComponent<WasmJsAppComponent>()
+                    .aboutRepository,
+            scope = coroutineScope,
+        )
+        onDispose {}
+    }
 
     // Create a single instance.
     val templateProvider =

--- a/composeApp/src/wasmJsMain/kotlin/activity/dashboard/WasmJsAppComponent.kt
+++ b/composeApp/src/wasmJsMain/kotlin/activity/dashboard/WasmJsAppComponent.kt
@@ -15,4 +15,5 @@ abstract class WasmJsAppComponent(
 ) :
     WasmJsAppComponentMerged {
     abstract val templateProviderFactory: TemplateProvider.Factory
+    abstract val aboutRepository: AboutRepository
 }


### PR DESCRIPTION
Fixing and cleaning up the About page, enable an experimental way to handle anchor routing to the About page to enable direct links to show it